### PR TITLE
🎨 Palette: Add loading spinner to gallery overlay

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-05-19 - [Gallery Keyboard and Visual Navigation]
 **Learning:** Image galleries that open in a full-screen overlay should not only support keyboard dismissal (Escape) but also keyboard navigation (Arrow keys). Relying solely on a "Close" button forces excessive mouse/touch interaction. Providing large, accessible visual navigation buttons helps both mouse and touch users discover that there's more to see.
 **Action:** Always implement `ArrowLeft` and `ArrowRight` keyboard listeners for image overlays. Provide visual "Previous" and "Next" buttons with clear ARIA labels and focus states.
+
+## 2025-05-20 - [Loading States for High-Res Images]
+**Learning:** High-resolution image galleries can feel unresponsive if there is no feedback during the transition between images or upon initial enlargement. Implementing a loading spinner and using CSS transitions to fade images in once they've loaded prevents "content flashing" and provides clear feedback that the application is working.
+**Action:** Use an `onLoad` handler on image elements to track loading state. Provide a visual indicator (like a spinner) and use a CSS `opacity` transition to smoothly reveal images once fully loaded.

--- a/app/aperture/[galleryId]/GalleryPage.css
+++ b/app/aperture/[galleryId]/GalleryPage.css
@@ -142,6 +142,31 @@
   height: auto;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  transition: opacity 0.3s ease;
+}
+
+.enlarged-image.loading {
+  opacity: 0;
+}
+
+.spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: #fff;
+  animation: spin 1s ease-in-out infinite;
+  z-index: 1002;
+}
+
+@keyframes spin {
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
 }
 
 /* Responsive layout adjustments */

--- a/app/aperture/[galleryId]/GalleryPageClient.tsx
+++ b/app/aperture/[galleryId]/GalleryPageClient.tsx
@@ -22,10 +22,14 @@ export default function GalleryPageClient({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [enlargedImage, setEnlargedImage] = useState<string | null>(null);
+  const [isImageLoading, setIsImageLoading] = useState(false);
 
   const navigate = (dir: number) => {
     const i = images.findIndex((img) => img.src === enlargedImage);
-    if (i !== -1) setEnlargedImage(images[(i + dir + images.length) % images.length].src);
+    if (i !== -1) {
+      setIsImageLoading(true);
+      setEnlargedImage(images[(i + dir + images.length) % images.length].src);
+    }
   };
 
   useEffect(() => {
@@ -107,7 +111,15 @@ export default function GalleryPageClient({
       <div className="gallery-container">
         <div className="gallery-grid">
           {images.map((image, index) => (
-            <button key={index} className="gallery-item" onClick={() => setEnlargedImage(image.src)} aria-label={`Enlarge image ${image.alt}`}>
+            <button
+              key={index}
+              className="gallery-item"
+              onClick={() => {
+                setIsImageLoading(true);
+                setEnlargedImage(image.src);
+              }}
+              aria-label={`Enlarge image ${image.alt}`}
+            >
               <img src={image.src} alt={image.alt} className="gallery-image" loading="lazy" />
             </button>
           ))}
@@ -119,7 +131,13 @@ export default function GalleryPageClient({
           <button className="close-overlay" onClick={() => setEnlargedImage(null)} aria-label="Close enlarged image">✕</button>
           <button className="nav-button prev" onClick={(e) => { e.stopPropagation(); navigate(-1); }} aria-label="Previous image">‹</button>
           <div className="overlay-content" onClick={(e) => e.stopPropagation()}>
-            <img src={enlargedImage} alt="Enlarged" className="enlarged-image" />
+            {isImageLoading && <div className="spinner" aria-hidden="true"></div>}
+            <img
+              src={enlargedImage}
+              alt="Enlarged"
+              className={`enlarged-image ${isImageLoading ? "loading" : ""}`}
+              onLoad={() => setIsImageLoading(false)}
+            />
           </div>
           <button className="nav-button next" onClick={(e) => { e.stopPropagation(); navigate(1); }} aria-label="Next image">›</button>
         </div>


### PR DESCRIPTION
🎨 Palette: Add loading spinner to gallery overlay

### 💡 What:
Added a visual loading spinner and a smooth fade-in transition to the enlarged image overlay in the photography gallery (`/aperture/[galleryId]`).

### 🎯 Why:
High-resolution photography files can take a few seconds to load. Previously, the overlay would remain static or show a flickering image during the load. The spinner provides immediate feedback that the application is fetching the high-res asset, improving perceived performance.

### ♿ Accessibility:
- The spinner is marked with `aria-hidden="true"` as it serves as visual feedback for a process already clear from context.
- Used CSS `opacity` transitions to prevent jarring visual "flashes" when the image finishes loading.
- Maintained existing keyboard navigation (`ArrowLeft`, `ArrowRight`, `Escape`) and focus management.

### Verification:
- Verified the loading UI by capturing a screenshot (`verification/spinner_visible.png`) using a Playwright script that simulated network delays for image assets.
- Confirmed the project builds successfully with `pnpm build`.
- Recorded UX learnings regarding loading states in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [5195220497757698151](https://jules.google.com/task/5195220497757698151) started by @lucasfth*