### PR TITLE
🎨 Palette: Improve gallery preview accessibility and keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-20 - [Loading States for High-Res Images]
 **Learning:** High-resolution image galleries can feel unresponsive if there is no feedback during the transition between images or upon initial enlargement. Implementing a loading spinner and using CSS transitions to fade images in once they've loaded prevents "content flashing" and provides clear feedback that the application is working.
 **Action:** Use an `onLoad` handler on image elements to track loading state. Provide a visual indicator (like a spinner) and use a CSS `opacity` transition to smoothly reveal images once fully loaded.
+
+## 2026-05-02 - [Gallery Accessibility and Keyboard Navigation]
+**Learning:** Wrapping interactive gallery previews in semantic `Link` components instead of generic `div` elements with `onClick` handlers is essential for keyboard accessibility and screen reader support. Adding `:focus-visible` styles ensures a clear visual indicator for users navigating with a keyboard.
+**Action:** Always use semantic interactive elements (like `Link` or `button`) for gallery triggers and ensure they have descriptive `aria-label`s and visible focus states.

--- a/components/GalleryContent.css
+++ b/components/GalleryContent.css
@@ -11,7 +11,14 @@
 
 .image-container {
   margin: 10px;
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, outline 0.2s ease;
+  display: block;
+}
+
+.image-container:focus-visible {
+  outline: 4px solid #0070f3;
+  outline-offset: 4px;
+  border-radius: 8px;
 }
 
 .image-container img {

--- a/components/GalleryContent.tsx
+++ b/components/GalleryContent.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import Link from "next/link";
 import "./GalleryContent.css";
 
 interface GalleryContentProps {
@@ -58,21 +59,19 @@ export default function GalleryContent({
               (child: any) => child.tagName === "img"
             );
             if (hasImage) {
+              const galleryId = props.href?.split("/").pop() || "gallery";
               return (
-                <div
+                <Link
+                  href={props.href || "#"}
                   className="image-container"
-                  onClick={() => handleImageContainerClick(props.href)}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleImageContainerClick(props.href);
+                  }}
+                  aria-label={`View ${galleryId} gallery`}
                 >
-                  <a
-                    {...props}
-                    className="image-link"
-                    onClick={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    {props.children}
-                  </a>
-                </div>
+                  {props.children}
+                </Link>
               );
             }
 


### PR DESCRIPTION
This PR improves the accessibility and keyboard navigability of the gallery previews on the Aperture page.

💡 **What:** 
- Swapped the `div` + `a` wrapper around gallery images for a single `Link` component from `next/link`.
- Added dynamic `aria-label` based on the gallery ID.
- Added `:focus-visible` styles to provide a clear blue outline when focusing on gallery previews via keyboard.

🎯 **Why:** 
Previously, the gallery previews were not keyboard-accessible because they used a generic `div` for the click handler. This made it impossible for keyboard users to activate the gallery view. Additionally, screen readers had no context about what these interactive images did.

♿ **Accessibility:**
- Interactive elements are now semantic and keyboard-discoverable.
- Screen readers now announce the purpose of the links (e.g., "View snow gallery").
- Focus states are clearly visible.

---
*PR created automatically by Jules for task [1033878353904700224](https://jules.google.com/task/1033878353904700224) started by @lucasfth*