### PR TITLE
🎨 Palette: Improve mobile navigation closure and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-05-02 - [Gallery Accessibility and Keyboard Navigation]
 **Learning:** Wrapping interactive gallery previews in semantic `Link` components instead of generic `div` elements with `onClick` handlers is essential for keyboard accessibility and screen reader support. Adding `:focus-visible` styles ensures a clear visual indicator for users navigating with a keyboard.
 **Action:** Always use semantic interactive elements (like `Link` or `button`) for gallery triggers and ensure they have descriptive `aria-label`s and visible focus states.
+
+## 2025-05-22 - [Mobile Navigation Closure Patterns]
+**Learning:** For mobile navigation menus that overlay content, users expect to be able to close the menu using the `Escape` key or by clicking anywhere outside the menu container. Implementing these listeners on the `window` or `document` only when the menu is open improves the perceived responsiveness and accessibility of the interface.
+**Action:** Use a `useRef` to track the navigation container and implement `Escape` and click-outside listeners in a `useEffect` that triggers when the menu state is `open`.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import "./Header.css";
@@ -8,10 +8,39 @@ import "./Header.css";
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+  const navRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     setIsOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        navRef.current &&
+        !navRef.current.contains(e.target as Node) &&
+        isOpen
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
@@ -25,7 +54,7 @@ export default function Header() {
   };
 
   return (
-    <nav className="navbar">
+    <nav className="navbar" ref={navRef}>
       <Link href="/" className="navbar-brand">
         <img src="/favicon.ico" alt="Logo" className="logo" />
         <span className="brand-name">Lucas Hanson</span>
@@ -36,11 +65,12 @@ export default function Header() {
         onClick={toggleMenu}
         aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
         aria-expanded={isOpen}
+        aria-controls="nav-menu"
       >
-        {isOpen ? "✕" : "☰"}
+        <span aria-hidden="true">{isOpen ? "✕" : "☰"}</span>
       </button>
 
-      <ul className={`nav-links ${isOpen ? "open" : ""}`}>
+      <ul id="nav-menu" className={`nav-links ${isOpen ? "open" : ""}`}>
         <li>
           <Link
             href="/"


### PR DESCRIPTION
### 🎨 Palette: Improve Mobile Navigation UX & Accessibility

#### 💡 What:
Improved the mobile navigation menu by implementing standard "close" patterns and enhancing ARIA attributes.

- **Interaction**: The mobile menu now closes automatically when the `Escape` key is pressed or when a user clicks anywhere outside the navigation menu.
- **Accessibility**:
    - Added `aria-controls="nav-menu"` to the hamburger button to link it with the navigation list.
    - Wrapped the burger icon (`☰` / `✕`) in `<span aria-hidden="true">` to ensure screen readers focus on the descriptive `aria-label`.
- **Documentation**: Added a new entry to `.Jules/palette.md` regarding mobile navigation closure patterns.

#### 🎯 Why:
Users expect intuitive ways to dismiss overlays. On mobile, clicking outside a menu or pressing Escape are standard interactions that were previously missing. These changes make the interface feel more responsive and accessible.

#### ♿ Accessibility Improvements:
- Proper ARIA relationship between toggle and menu.
- Keyboard support for dismissing the menu.
- Cleaner screen reader experience by hiding decorative symbols.

#### ✅ Verification:
Verified using a Playwright script that simulates opening the menu, pressing Escape, and clicking outside. The project builds successfully with no regressions.


---
*PR created automatically by Jules for task [1674404163580477166](https://jules.google.com/task/1674404163580477166) started by @lucasfth*