### PR TITLE
🎨 Palette: Add copy to clipboard button to code blocks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -67,6 +67,16 @@ a:focus-visible {
   border-width: 0;
 }
 
+.code-block-wrapper { position: relative; margin: 1.5rem 0; }
+.copy-button {
+  position: absolute; top: 8px; right: 8px; background: rgba(255, 255, 255, 0.8);
+  border: 1px solid #ccc; border-radius: 4px; padding: 4px 8px; font-size: 0.75rem;
+  font-family: 'Space Mono', monospace; cursor: pointer; z-index: 1; transition: all 0.2s ease; line-height: 1;
+}
+.copy-button:hover { background: #fff; border-color: #999; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); }
+.copy-button:active { transform: translateY(0); }
+.copy-button:focus-visible { outline: 2px solid #0070f3; outline-offset: 2px; }
+
 .App {
   overflow-x: hidden;
 }

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useState } from "react";
+
+export default function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+  return (
+    <button onClick={handleCopy} className="copy-button" aria-label={copied ? "Copied!" : "Copy code"}>
+      {copied ? "✓ Copied" : "Copy"}
+    </button>
+  );
+}

--- a/components/TextSection.tsx
+++ b/components/TextSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { materialLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+import CopyButton from "./CopyButton";
 
 interface TextSectionProps {
   markdown: string;
@@ -20,21 +21,25 @@ export default function TextSection({ markdown }: TextSectionProps) {
           components={{
             code({ node, inline, className, children, ...props }: any) {
               const match = /language-(\w+)/.exec(className || "");
+              const codeContent = String(children).replace(/\n$/, "");
               return !inline && match ? (
-                <SyntaxHighlighter
-                  style={{
-                    ...materialLight,
-                    'pre[class*="language-"]': {
-                      ...materialLight['pre[class*="language-"]'],
-                      borderRadius: "8px",
-                    },
-                  }}
-                  language={match[1]}
-                  PreTag="div"
-                  {...props}
-                >
-                  {String(children).replace(/\n$/, "")}
-                </SyntaxHighlighter>
+                <div className="code-block-wrapper">
+                  <CopyButton text={codeContent} />
+                  <SyntaxHighlighter
+                    style={{
+                      ...materialLight,
+                      'pre[class*="language-"]': {
+                        ...materialLight['pre[class*="language-"]'],
+                        borderRadius: "8px",
+                      },
+                    }}
+                    language={match[1]}
+                    PreTag="div"
+                    {...props}
+                  >
+                    {codeContent}
+                  </SyntaxHighlighter>
+                </div>
               ) : (
                 <code className={className} {...props}>
                   {children}


### PR DESCRIPTION
I have implemented a "Copy to Clipboard" feature for all code blocks within the `TextSection` component (used in the blog and projects sections).

### 💡 What:
- Added a new `CopyButton` client component that handles the `navigator.clipboard` API.
- Wrapped code blocks in a `code-block-wrapper` to position the button.
- Included a "✓ Copied" feedback state that lasts for 2 seconds after a successful copy.

### 🎯 Why:
This is a standard micro-UX improvement for technical blogs and portfolios. It saves users from having to manually select and copy long code snippets, reducing friction and potential errors.

### ♿ Accessibility:
- The button includes a descriptive `aria-label` that updates based on the copy state ("Copy code" vs "Copied!").
- High-contrast focus-visible styles are applied for keyboard navigation.
- Semantic HTML was used throughout.

### 📸 Verification:
I verified the change using a Playwright script that navigates to a blog post, scrolls to a code block, clicks the copy button, and confirms the "Copied" feedback state. The code has been cleaned of any unrelated build artifacts or lockfile noise.

**Line count:** 46 insertions (verified via git diff).

---
*PR created automatically by Jules for task [15693291090881405686](https://jules.google.com/task/15693291090881405686) started by @lucasfth*