### PR TITLE
🎨 Palette: Enhanced Markdown link accessibility and performance

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,28 +1,15 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import PageShell from "@/components/PageShell";
 import { useMarkdown } from "@/hooks/useMarkdown";
 
 export default function Blog() {
   const { content, loading, error } = useMarkdown("/content/blog.md");
-  const router = useRouter();
-
-  const handleLinkClick = (e: React.MouseEvent) => {
-    const target = (e.target as HTMLElement).closest("a");
-    if (target && target.getAttribute("href")?.startsWith("/blog/")) {
-      e.preventDefault();
-      const path = target.getAttribute("href");
-      if (path) router.push(path);
-    }
-  };
 
   if (loading) return <div className="common-container"><div className="inner-container"><p>Loading...</p></div></div>;
   if (error) return <div className="common-container"><div className="inner-container"><p>Error: {error}</p></div></div>;
 
   return (
-    <div onClick={handleLinkClick}>
-      <PageShell markdown={content} />
-    </div>
+    <PageShell markdown={content} />
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,29 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import PageShell from "@/components/PageShell";
 import { useMarkdown } from "@/hooks/useMarkdown";
 
 export default function Projects() {
   const { content, loading, error } = useMarkdown("/content/projects.md");
-  const router = useRouter();
-
-  const handleLinkClick = (e: React.MouseEvent) => {
-    const target = (e.target as HTMLElement).closest("a");
-    if (target && target.getAttribute("href")?.startsWith("/projects/")) {
-      e.preventDefault();
-      const path = target.getAttribute("href");
-      if (path) router.push(path);
-    }
-  };
 
   if (loading) return <div className="common-container"><div className="inner-container"><p>Loading...</p></div></div>;
   if (error) return <div className="common-container"><div className="inner-container"><p>Error: {error}</p></div></div>;
 
   return (
-    <div onClick={handleLinkClick}>
-      <PageShell markdown={content} />
-    </div>
+    <PageShell markdown={content} />
   );
 }

--- a/components/GalleryContent.tsx
+++ b/components/GalleryContent.tsx
@@ -54,30 +54,48 @@ export default function GalleryContent({
               </div>
             );
           },
-          a: ({ node, ...props }: any) => {
+          a: ({ node, href, children, ...props }: any) => {
             // if this anchor wraps an image, render a block-level container
             const hasImage = node?.children?.some(
               (child: any) => child.tagName === "img"
             );
             if (hasImage) {
-              const galleryId = props.href?.split("/").pop() || "gallery";
+              const galleryId = href?.split("/").pop() || "gallery";
               return (
                 <Link
-                  href={props.href || "#"}
+                  href={href || "#"}
                   className="image-container"
                   onClick={(e) => {
                     e.preventDefault();
-                    handleImageContainerClick(props.href);
+                    handleImageContainerClick(href);
                   }}
                   aria-label={`View ${galleryId} gallery`}
                 >
-                  {props.children}
+                  {children}
                 </Link>
               );
             }
 
             // otherwise render a normal inline anchor
-            return <a {...props}>{props.children}</a>;
+            const isInternal = href?.startsWith("/") || href?.startsWith("#");
+            if (isInternal) {
+              return (
+                <Link href={href || "#"} {...props}>
+                  {children}
+                </Link>
+              );
+            }
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...props}
+              >
+                {children}
+                <span className="sr-only"> (opens in a new tab)</span>
+              </a>
+            );
           },
 
           img: ({ node, ...props }: any) => (

--- a/components/TextSection.tsx
+++ b/components/TextSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import Link from "next/link";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
   materialLight,
@@ -37,6 +38,27 @@ export default function TextSection({ markdown }: TextSectionProps) {
       <div className="inner-container">
         <ReactMarkdown
           components={{
+            a({ node, href, children, ...props }: any) {
+              const isInternal = href?.startsWith("/") || href?.startsWith("#");
+              if (isInternal) {
+                return (
+                  <Link href={href} {...props}>
+                    {children}
+                  </Link>
+                );
+              }
+              return (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  {...props}
+                >
+                  {children}
+                  <span className="sr-only"> (opens in a new tab)</span>
+                </a>
+              );
+            },
             code({ node, inline, className, children, ...props }: any) {
               const match = /language-(\w+)/.exec(className || "");
               const codeContent = String(children).replace(/\n$/, "");


### PR DESCRIPTION
💡 **What:** Unified and enhanced link handling within Markdown content across the site.
- Internal links (starting with `/` or `#`) now use `next/link` for faster, client-side SPA transitions.
- External links now include `rel="noopener noreferrer"` and visually hidden text for screen readers (e.g., "(opens in a new tab)") via the `.sr-only` utility.
- Removed redundant manual event delegation and `useRouter` logic in the `Projects` and `Blog` page components, as the Markdown renderer now handles these transitions natively.

🎯 **Why:** This improvement provides a more consistent and performant navigation experience while significantly enhancing accessibility for screen reader users who now receive explicit context when a link opens in a new tab.

♿ **Accessibility:**
- Added `.sr-only` text to all external links.
- Ensured consistent focus and navigation behavior across all Markdown-rendered content.

---
*PR created automatically by Jules for task [1356371004565705850](https://jules.google.com/task/1356371004565705850) started by @lucasfth*