### PR TITLE
🎨 Palette: Add Scroll to Top button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-06-06 - [Modal Focus Management]
 **Learning:** Proper focus management in modals/overlays is a critical accessibility requirement often missed in image galleries. This includes trapping focus within the modal, setting initial focus to a sensible element (like the Close button), and restoring focus to the original trigger upon closure.
 **Action:** Always implement a focus trap using `onKeyDown` to capture `Tab` and `Shift+Tab`. Store the `document.activeElement` before opening the modal to restore it on close. Use a small `setTimeout` or `useEffect` to ensure focus is applied after the DOM has rendered.
+
+## 2026-06-25 - [Scroll to Top Micro-UX]
+**Learning:** For long-form content websites like portfolios and blogs, a "Scroll to Top" button significantly enhances navigation efficiency once the user has scrolled past the initial fold. Using smooth scrolling and subtle transitions provides a delightful feel without being intrusive.
+**Action:** Implement a floating action button that appears after a scroll threshold (e.g., 300px), ensuring it has proper ARIA labels and respects the design system's accent colors.

--- a/app/globals.css
+++ b/app/globals.css
@@ -234,3 +234,21 @@ img {
   outline-offset: 2px;
   border-radius: 4px;
 }
+.scroll-to-top {
+  position: fixed; bottom: 20px; right: 20px;
+  background: var(--bg-secondary); color: var(--text-primary);
+  border: 1px solid var(--border-color); border-radius: 50%;
+  width: 44px; height: 44px; display: flex;
+  justify-content: center; align-items: center;
+  cursor: pointer; z-index: 100; opacity: 0;
+  visibility: hidden; transition: all 0.3s ease;
+  box-shadow: 0 2px 5px var(--shadow);
+}
+.scroll-to-top.visible { opacity: 1; visibility: visible; }
+.scroll-to-top:hover {
+  background: var(--bg-primary); border-color: var(--accent);
+  color: var(--accent); transform: translateY(-2px);
+}
+.scroll-to-top:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import ScrollToTop from "@/components/ScrollToTop";
 
 export const metadata = {
   title: "Lucas Hanson",
@@ -85,6 +86,7 @@ export default function RootLayout({
           </main>
           <Footer />
         </div>
+        <ScrollToTop />
       </body>
     </html>
   );

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 300);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  return (
+    <button
+      className={`scroll-to-top ${show ? "visible" : ""}`}
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      aria-label="Scroll to top"
+    ><span aria-hidden="true">↑</span></button>
+  );
+}


### PR DESCRIPTION
💡 **What**: Added a globally available "Scroll to Top" button that smoothly appears after the user scrolls 300px down the page.

🎯 **Why**: This improves navigation on long pages (such as the "About me" front page or blog posts), allowing users to quickly return to the main navigation menu without excessive scrolling.

♿ **Accessibility**:
- Includes a descriptive `aria-label="Scroll to top"`.
- Wraps the decorative arrow in `aria-hidden="true"`.
- Utilizes existing design system variables for consistent focus states and colors.
- Inherits the site's `prefers-reduced-motion` compatible smooth scroll behavior.

🎨 **Visuals**: A clean, circular floating action button that follows the site's minimalist aesthetic and "Space Mono" typography.

---
*PR created automatically by Jules for task [3058864832601481957](https://jules.google.com/task/3058864832601481957) started by @lucasfth*