### PR TITLE
🎨 Palette: Enhance Header Accessibility and UX

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,6 +9,7 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
   const navRef = useRef<HTMLElement>(null);
+  const burgerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     setIsOpen(false);
@@ -18,6 +19,23 @@ export default function Header() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape" && isOpen) {
         setIsOpen(false);
+        burgerRef.current?.focus();
+      }
+
+      if (e.key === "Tab" && isOpen && navRef.current) {
+        const focusable = navRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0] as HTMLElement;
+        const last = focusable[focusable.length - 1] as HTMLElement;
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
 
@@ -55,14 +73,20 @@ export default function Header() {
 
   return (
     <nav className="navbar" ref={navRef}>
-      <Link href="/" className="navbar-brand">
-        <img src="/favicon.ico" alt="Logo" className="logo" />
+      <Link
+        href="/"
+        className="navbar-brand"
+        onClick={() => setIsOpen(false)}
+        aria-current={pathname === "/" ? "page" : undefined}
+      >
+        <img src="/favicon.ico" alt="" className="logo" />
         <span className="brand-name">Lucas Hanson</span>
       </Link>
 
       <button
         className="burger-menu"
         onClick={toggleMenu}
+        ref={burgerRef}
         aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
         aria-expanded={isOpen}
         aria-controls="nav-menu"
@@ -76,6 +100,7 @@ export default function Header() {
             href="/"
             className={isActive("/") ? "active" : ""}
             aria-current={isActive("/") ? "page" : undefined}
+            onClick={() => setIsOpen(false)}
           >
             <span aria-hidden="true">🌤</span> About me
           </Link>
@@ -85,6 +110,7 @@ export default function Header() {
             href="/projects"
             className={isActive("/projects") ? "active" : ""}
             aria-current={isActive("/projects") ? "page" : undefined}
+            onClick={() => setIsOpen(false)}
           >
             <span aria-hidden="true">👨‍💻</span> Projects
           </Link>
@@ -94,6 +120,7 @@ export default function Header() {
             href="/blog"
             className={isActive("/blog") ? "active" : ""}
             aria-current={isActive("/blog") ? "page" : undefined}
+            onClick={() => setIsOpen(false)}
           >
             <span aria-hidden="true">✍️</span> Blog
           </Link>
@@ -103,6 +130,7 @@ export default function Header() {
             href="/aperture"
             className={isActive("/aperture") ? "active" : ""}
             aria-current={isActive("/aperture") ? "page" : undefined}
+            onClick={() => setIsOpen(false)}
           >
             <span aria-hidden="true">📷</span> Aperture
           </Link>


### PR DESCRIPTION
This PR implements a set of micro-UX and accessibility improvements to the navigation header.

### 💡 What
- **Focus Management**: Implemented a focus trap within the mobile navigation menu. When the menu is open, tabbing now wraps between the navigation links and the brand/burger elements.
- **Focus Restoration**: Pressing the `Escape` key now closes the menu and returns focus to the burger button, preventing focus loss.
- **Improved Interaction**: Added explicit close handlers to all navigation links. Previously, the menu only closed on route change; now it also closes if a user clicks a link to the current page.
- **Accessibility Polish**: Set the brand logo's `alt` attribute to an empty string (as it is decorative next to the brand name) and added `aria-current="page"` to the brand link when on the homepage.

### 🎯 Why
- Keyboard and screen reader users previously experienced "focus leakage" where they could tab into the background content while the mobile menu was open.
- Mobile users found the menu persistent even after clicking a link to the same page, creating a "stuck" feeling.
- Screen readers would unnecessarily announce "Logo" followed by the name, which is redundant.

### ♿ Accessibility
- Verified with Playwright that focus is trapped and restored correctly.
- Enhanced semantic navigation with `aria-current`.
- Improved keyboard navigation flow for the mobile overlay.

---
*PR created automatically by Jules for task [5182051788716250808](https://jules.google.com/task/5182051788716250808) started by @lucasfth*